### PR TITLE
Bump ossf/scorecard-action to v2.0.6

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@08dd0cebb088ac0fd6364339b1b3b68b75041ea8 # v2.0.0-alpha.2
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Description

The latest version of `scorecard-action` resolves an issue related to signing scorecard JSON results.


More context: https://github.com/ossf/scorecard-action/issues/997
