### PR TITLE
Update scorecards workflow and security policy

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518 # v2.1.0
+        uses: step-security/harden-runner@1b05615854632b887b69ae1be8cbefe72d3ae423 # v2.6.0
         with:
           disable-sudo: true
           egress-policy: block
@@ -31,18 +31,18 @@ jobs:
             api.osv.dev:443
             api.securityscorecards.dev:443
             bestpractices.coreinfrastructure.org:443
-            fulcio.sigstore.dev:443
             github.com:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
+            *.sigstore.dev:443
+            *.bestpractices.dev:443
+            *.storage.googleapis.com:443
 
       - name: "Checkout code"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif
@@ -61,7 +61,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
           path: results.sarif
@@ -69,6 +69,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@3ebbd71c74ef574dbc558c82f70e52732c8b44fe # v2.2.1
+        uses: github/codeql-action/upload-sarif@74483a38d39275f33fcff5f35b679b5ca4a26a99 # v2.22.5
         with:
           sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,13 @@
-# Reporting Security Issues
+# Security Policy
 
-To report a security issue, please email [oss@kommit.co](mailto:oss@kommit.co) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+## Reporting Security Issues
+
+To report a security issue, you can either:
+- Privately report a vulnerability through repository's Security tab by clicking "Report a vulnerability".
+- Email us at [oss@kommit.co](mailto:oss@kommit.co).
+
+Please, make sure to provide a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+## Responsible Disclosure
 
 If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it.


### PR DESCRIPTION
## Description

Update scorecards workflow and security policy.

- GitHub actions in the scorecards workflow were bumped.
- Security policy was updated to be a little more detailed and also includes 2 or more hints which match "vuln" or "discl" to improve the Scorecards' SECURITY score to 10.

